### PR TITLE
chore: remove Sema and add other communities

### DIFF
--- a/Open-Source/Communities/Readme.md
+++ b/Open-Source/Communities/Readme.md
@@ -1,8 +1,9 @@
 ## Communities you can join 👇
 
 - [WeMakeDevs](https://discord.gg/wemakedevs)
-- [Eddiehub](http://discord.eddiehub.org/)
+- [EddieHub](http://discord.eddiehub.org/)
 - [Geek Around Community](https://discord.io/geekaroundcommunity)
 - [MLH](https://discord.gg/mlh)
-- [Sema](http://discord.gg/Byjr6rdBUZ)
-- [cs dojo](https://discord.com/invite/nNtVfKddDD)
+- [Hacktoberfest](https://discord.gg/hacktoberfest)
+- [CS Dojo](https://discord.com/gg/nNtVfKddDD)
+- [The Algorithms](https://the-algorithms.com/discord)


### PR DESCRIPTION
## Changes proposed

- Remove Sema from the open-source communities, as that product is no longer maintained.
- Added Hacktoberfest and The Algorithms communities.
  - [Hacktoberfest](https://hacktoberfest.com) is a yearly event that helps beginners get started in open-source, which many people have participated in.
  - [The Algorithms](https://the-algorithms.com) is an open-source resource to learn DSA with documented programs using the latest code. Its biggest repository has 100K+ stars, being the 21st most starred repository on GitHub.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
