### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Community Classroom
+Copyright (c) 2023 WeMakeDevs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changing copyright from the old "Community Classroom" to "WeMakeDevs" and also updating copyright year from 2022 to 2023.

## Changes proposed

Updating copyright name from "Community Classroom" to "WeMakeDevs"

## Screenshots

![image](https://user-images.githubusercontent.com/42804812/226177413-8535cc23-4c30-423b-80cc-bb81c5542fbb.png)
