### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 WeMakeDevs
+Copyright (c) 2022 WeMakeDevs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
``
## Changes proposed
Changing copyright year back to 2022.
As 2022 is the year Community Classroom was Rebranded to WeMakeDevs. 
 