### PR TITLE
fixed DoK Slack link

### DIFF
--- a/DevOps/Communities/Readme.md
+++ b/DevOps/Communities/Readme.md
@@ -7,7 +7,7 @@
 - [Kubernetes Twitter](https://twitter.com/i/communities/1444745802383953921)
 - [Kubernetes Slack](https://kubernetes.slack.com/)
 - [CNCF Slack](https://slack.cncf.io/)
-- [DoK Slack](https://dokcommunity.slack.com/)
+- [DoK Slack](https://dokcommunity.slack.com/join/shared_invite/zt-1vgv7ymz7-YtLFvZicrcLP9fS3o_r2_w#/shared-invite/email)
 - [Gopher Slack](https://invite.slack.golangbridge.org/)
 - [Kubescape Discord](https://discord.com/invite/WKZRaCtBxN)
 - [MlOps](https://mlops.community/)


### PR DESCRIPTION
## Fixes Issue
Closes #620


## Changes proposed
- I checked the **DoK Slack Link** on their website, and it seems like the link has been updated.
- Hence, I updated the `Readme.md` file under the `WeMakeDevs/roadmaps/DevOps/Communities`.
- This is the [Old Link](https://dokcommunity.slack.com/)
- This is the [New Link](https://dokcommunity.slack.com/join/shared_invite/zt-1vgv7ymz7-YtLFvZicrcLP9fS3o_r2_w#/shared-invite/email)


## Screenshots
Now, it takes to this website:

![Screenshot 2023-08-06 at 7 26 09 PM](https://github.com/WeMakeDevs/roadmaps/assets/113309726/612faa1a-bf52-454f-a4ab-18859b3175e9)



## Note to reviewers

<!-- Add notes to reviewers if applicable -->
