### PR TITLE
Some of the links are expired of the Discord Community

### DIFF
--- a/Android-Development/Communities/Readme.md
+++ b/Android-Development/Communities/Readme.md
@@ -7,6 +7,6 @@
 - [AndroidDev](https://discord.gg/8hy5FmN)
 - [Official Flutter](https://discord.gg/BS8KZyg)
 - [Dart](https://discord.gg/Qt6DgfAWWx)
-- [Full-Stack Dev](https://discord.gg/53wzPYyw)
-- [Academind](https://discord.gg/hbhcZPbs)
+- [Full-Stack Dev](https://discord.gg/MpcxJSSHUK)
+- [Academind](https://discord.gg/gxvEWGU)
 - [HackThisFall](https://discord.gg/hack-this-fall-736562838453354576)

--- a/Flutter-Development/Communities/readme.md
+++ b/Flutter-Development/Communities/readme.md
@@ -3,5 +3,5 @@
 - [Official Flutter](https://discord.gg/BS8KZyg)
 - [Dart](https://discord.gg/Qt6DgfAWWx)
 - [Full-Stack Dev](https://discord.gg/53wzPYyw)
-- [Academind](https://discord.gg/hbhcZPbs)
+- [Academind](https://discord.gg/gxvEWGU)
 - [AndroidDev](https://discord.gg/8hy5FmN)

--- a/Hacktoberfest-Readme.md
+++ b/Hacktoberfest-Readme.md
@@ -23,7 +23,7 @@ It is open to everyone in the community and anyone whether you're a seasoned con
 - [DevRel](https://github.com/WeMakeDevs/roadmaps/tree/main/DevRel)
 - [Frontend-Development](https://github.com/WeMakeDevs/roadmaps/tree/main/Frontend-Development)
 - [Fullstack-Development](https://github.com/WeMakeDevs/roadmaps/tree/main/Fullstack-Development)
-- [Mobile-Development](https://github.com/WeMakeDevs/roadmaps/tree/main/Mobile-Development)
+- [Android-Development](https://github.com/WeMakeDevs/roadmaps/tree/main/Android-Development)
 - [Open-Source](https://github.com/WeMakeDevs/roadmaps/tree/main/Open-Source)
 
 ## **WeMakeDevs Guidelines 🥸**


### PR DESCRIPTION
## Fixes Issue

- Updated the Community Link which were expired in Android Development Roadmap
- Update Community Link which were expired in Flutter Development Roadmap
- Added correct android development roadmap in Hacktoberfest markdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

"Documentation":
- Updated Discord server URLs for "Full-Stack Dev" and "Academind" communities in Android Development section.
- Refreshed the Discord invitation link for the "Academind" community in Flutter Development section.
- Corrected the URL for the renamed "Mobile-Development" section to "Android-Development" in Hacktoberfest Readme.

These changes ensure users are directed to the correct and active community servers, enhancing their experience and engagement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->